### PR TITLE
Add Heroku Postbuild Step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "npm run build && node dist/worker.js",
     "build": "rimraf dist/ && babel src -d dist/",
+    "heroku-postbuild": "echo skip build on Heroku",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Added `heroku-postbuild` to the package.json file per [the heroku build script change doc](https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq) to prevent the npm build script from running every time the heroku worker runs.